### PR TITLE
Refactor unused annotations and standards

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -26,9 +26,7 @@ class Cache
     }
 
     /**
-     * @param string $language
-     *
-     * @return array
+     * @return list<string>
      *
      * @throws LanguageNotFoundException
      * @throws IrregularLanguageFileException

--- a/src/StopWords.php
+++ b/src/StopWords.php
@@ -6,11 +6,12 @@ namespace StopWords;
 
 class StopWords
 {
+    /**
+     * @var list<string> $words
+     */
     private $words;
 
     /**
-     * @param string $language
-     *
      * @throws LanguageNotFoundException
      * @throws IrregularLanguageFileException
      */

--- a/src/StopWords.php
+++ b/src/StopWords.php
@@ -8,6 +8,18 @@ class StopWords
 {
     private $words;
 
+    /**
+     * @param string $language
+     *
+     * @throws LanguageNotFoundException
+     * @throws IrregularLanguageFileException
+     */
+    public function __construct(string $language)
+    {
+        $cache = new Cache();
+        $this->words = $cache->find($language);
+    }
+
     public function clean(string $message): string
     {
         $message = $this->sanitize($message);
@@ -27,17 +39,5 @@ class StopWords
     private function sanitize(string $message): string
     {
         return mb_ereg_replace("/[^\p{L}\p{N}\_\s\-]/", " ", $message);
-    }
-
-    /**
-     * @param string $language
-     *
-     * @throws LanguageNotFoundException
-     * @throws IrregularLanguageFileException
-     */
-    public function __construct(string $language)
-    {
-        $cache = new Cache();
-        $this->words = $cache->find($language);
     }
 }


### PR DESCRIPTION
- Brings `StopWord::__construct` to the top of the class to maintain standard consistency.
- Removes annotations that do not provide any value.
- Adds array structure annotations.